### PR TITLE
Refined Cookie Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ yarn seed
 yarn dev
 ```
 
-- There are three modes available: `development`, `mock-production`, and `production`. The difference is that `development` shows the full error stack trace, `mock-production` shows the proper error messages for production usage, and `production` also sets the cookie property to be `secure`. You may change the environment by using `export` keyword or by changing it in `.env`.
+- There are two modes available: `development`, and `production`. The difference is that `development` shows the full error stack trace when the app throws an error, and `production` shows the proper, appropriate error messages.
 
 ## License
 

--- a/api/extensions.d.ts
+++ b/api/extensions.d.ts
@@ -7,7 +7,7 @@ declare global {
       JWT_ISSUER?: string;
       JWT_PRIVATE_KEY: string;
       JWT_PUBLIC_KEY: string;
-      NODE_ENV?: 'production' | 'development' | 'mock-production';
+      NODE_ENV?: 'production' | 'development';
       PORT?: number;
       TOTP_ISSUER?: string;
     }

--- a/api/infra/express.ts
+++ b/api/infra/express.ts
@@ -37,10 +37,7 @@ function loadExpress() {
   app.use(hpp());
 
   // Use logging on application.
-  if (
-    config.NODE_ENV === 'production' ||
-    config.NODE_ENV === 'mock-production'
-  ) {
+  if (config.NODE_ENV === 'production') {
     app.use(morgan('combined'));
   } else {
     app.use(morgan('dev'));

--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -100,11 +100,7 @@ const AuthController = {
         return;
       }
 
-      res.cookie('attendance-jws', 'loggedOut', {
-        httpOnly: true,
-        secure: config.NODE_ENV === 'production',
-        maxAge: 0,
-      });
+      res.cookie('attendance-jws', 'loggedOut', { maxAge: 10 });
 
       sendResponse({
         req,
@@ -261,7 +257,7 @@ const AuthController = {
     // set cookie
     const options: CookieOptions = {
       httpOnly: true,
-      secure: config.NODE_ENV === 'production',
+      secure: req.secure || req.headers['x-forwarded-proto'] === 'https',
       sameSite: 'strict',
       maxAge: 900000, // 15 minutes
       signed: true,

--- a/api/modules/error/index.ts
+++ b/api/modules/error/index.ts
@@ -133,10 +133,7 @@ const errorHandler = (
     sendErrorDevelopment(error, req, res);
   }
 
-  if (
-    config.NODE_ENV === 'production' ||
-    config.NODE_ENV === 'mock-production'
-  ) {
+  if (config.NODE_ENV === 'production') {
     sendErrorProduction(handleProductionErrors(error), req, res);
   }
 


### PR DESCRIPTION
This PR implements `secure` cookies by using `req.secure` and `req.headers['x-forwarded-proto'] === true`.

Because of that, there is now no longer any requirement to use `mock-production` environment. `production` works fine.