### PR TITLE
OTP Endpoint Guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Request -> Handler/Router -> Middleware (if applicable) -> Validations (if appli
 - Global error handler exist in the application. Every error(s) will be thrown to the global error handler to be 'handled'.
 - We still have not yet used Dependency Injection for easier testability.
 
+## Documentation
+
+API documentation is available at Postman, and it is under construction for now.
+
 ## Requirements
 
 For development, you need the following technologies installed on your machine:
@@ -82,15 +86,10 @@ yarn genkeys
 
 - You will get the Base64-encoded public-private key pairs for the JWT, and you have to copy it in your `.env` file. Instructions are also provided after that script has finished running in case you forgot.
 
-- Run Prisma migrations, so you can get the database schema. You have to do this every time you turn on the Docker instance, as all data are reset.
+- Run Prisma migrations and seeders so you can get the database schema that is already populated with the sample data (sample data is at `api/cli/seed-data.ts`). You have to do this every time you turn on the Docker instance, as all data are reset.
 
 ```bash
 yarn migrate
-```
-
-- You may seed the database with data samples located at `api/cli/seed-data.ts`. As above, you also have to do this every time you turn on the Docker instance.
-
-```bash
 yarn seed
 ```
 

--- a/api/modules/cache/repository.ts
+++ b/api/modules/cache/repository.ts
@@ -5,13 +5,18 @@ import redis from '../../infra/redis';
  */
 const CacheRepository = {
   /**
-   * Sets the OTP session of a user.
+   * Gets whether the user has asked OTP or not.
    *
-   * @param jti - JSON Web Identifier as 'key'.
-   * @param value - Value to be stored, usually 'user identifier'.
+   * @param userID - A user's ID
    */
-  setOTPSession: async (jti: string, value: string) =>
-    redis.setex(`otp-sess:${jti}`, 900, value),
+  getHasAskedOTP: async (userID: string) => redis.get(`asked-otp:${userID}`),
+
+  /**
+   * Gets the number of OTP attempts that is done by a user.
+   *
+   * @param userID - ID of the user.
+   */
+  getOTPAttempts: async (userID: string) => redis.get(`otp-attempts:${userID}`),
 
   /**
    * Gets the OTP session related to a JTI.
@@ -27,6 +32,39 @@ const CacheRepository = {
    * @returns An asynchronous 'PONG' string.
    */
   ping: async () => redis.ping(),
+
+  /**
+   * Sets in the cache whether the user has asked for OTP or not.
+   * TTL is 30 seconds. This will be used to prevent a user's spamming for OTP requests.
+   *
+   * @param userID - ID of the user.
+   */
+  setHasAskedOTP: async (userID: string) =>
+    redis.setex(`asked-otp:${userID}`, 30, 'true'),
+
+  /**
+   * Sets the number of OTP 'wrong' attempts of a single user.
+   * TTL is 86400 seconds or a single day. Will use Redis's 'INCR' method to ensure atomic operations.
+   *
+   * @param userID - ID of the user.
+   */
+  setOTPAttempts: async (userID: string) => {
+    const currentAttempts = await redis.get(`otp-attempts:${userID}`);
+    if (currentAttempts === null) {
+      await redis.setex(`otp-attempts:${userID}`, 86400, '1');
+    } else {
+      await redis.incr(`otp-attempts:${userID}`);
+    }
+  },
+
+  /**
+   * Sets the OTP session of a user. TTL is 900 seconds or 15 minutes.
+   *
+   * @param jti - JSON Web Identifier as 'key'.
+   * @param value - Value to be stored, usually 'user identifier'.
+   */
+  setOTPSession: async (jti: string, value: string) =>
+    redis.setex(`otp-sess:${jti}`, 900, value),
 };
 
 export default CacheRepository;

--- a/api/modules/cache/service.ts
+++ b/api/modules/cache/service.ts
@@ -5,13 +5,20 @@ import CacheRepository from './repository';
  */
 const CacheService = {
   /**
-   * Sets the OTP session. Autheticates a user.
+   * Gets whether the user has asked OTP or not.
    *
-   * @param jti - JSON Web Identifier, to be used as the 'key'.
-   * @param value - Value of the 'key-value' pair.
+   * @param userID - A user's ID
    */
-  setOTPSession: async (jti: string, value: string) =>
-    CacheRepository.setOTPSession(jti, value),
+  getHasAskedOTP: async (userID: string) =>
+    CacheRepository.getHasAskedOTP(userID),
+
+  /**
+   * Gets the number of OTP attempts that is done by a user.
+   *
+   * @param userID - ID of the user.
+   */
+  getOTPAttempts: async (userID: string) =>
+    CacheRepository.getOTPAttempts(userID),
 
   /**
    * Gets the OTP session of a user.
@@ -27,6 +34,31 @@ const CacheService = {
    * @returns Asynchronous 'PONG' string.
    */
   ping: async () => CacheRepository.ping(),
+
+  /**
+   * Sets in the cache whether the user has asked for OTP or not.
+   *
+   * @param userID - ID of the user.
+   */
+  setHasAskedOTP: async (userID: string) =>
+    CacheRepository.setHasAskedOTP(userID),
+
+  /**
+   * Sets the number of OTP 'wrong' attempts of a single user.
+   *
+   * @param userID - ID of the user.
+   */
+  setOTPAttempts: async (userID: string) =>
+    CacheRepository.setOTPAttempts(userID),
+
+  /**
+   * Sets the OTP session. Autheticates a user.
+   *
+   * @param jti - JSON Web Identifier, to be used as the 'key'.
+   * @param value - Value of the 'key-value' pair.
+   */
+  setOTPSession: async (jti: string, value: string) =>
+    CacheRepository.setOTPSession(jti, value),
 };
 
 export default CacheService;


### PR DESCRIPTION
Implements:

- If a user has recently asked for an OTP, they have to wait for 30 seconds before the server issues another one. This is to prevent spam.
- If a user fails to input the correct OTP for three times in a successive manner, restrict access to the MFA session in the app for 24 hours.
- Improve documentation.