### PR TITLE
Current User Status Endpoint

### DIFF
--- a/api/modules/middleware/get-status.ts
+++ b/api/modules/middleware/get-status.ts
@@ -1,0 +1,119 @@
+// TODO: 'beautify' code here
+import type { Request, Response } from 'express';
+import * as jose from 'jose';
+
+import config from '../../config';
+import sendResponse from '../../util/send-response';
+import CacheService from '../cache/service';
+import UserService from '../user/service';
+
+/**
+ * This function is used to verify the current token from user's cookie.
+ * We will also check the supposed 'audience' and 'issuer'.
+ *
+ * @param token - JWT token
+ * @returns A promise object that contains our JWT.
+ */
+const verifyToken = async (token: string) => {
+  const publicKey = await jose.importSPKI(config.JWT_PUBLIC_KEY, 'EdDSA');
+
+  const options: jose.JWTVerifyOptions = {
+    audience: config.JWT_AUDIENCE,
+    issuer: config.JWT_ISSUER,
+  };
+
+  return jose.jwtVerify(token, publicKey, options);
+};
+
+/**
+ * Extracts a token from either Authorization header or signed cookie.
+ * Prioritize token from Authorization header.
+ *
+ * @param header - Authorization header value
+ * @param signedCookie - Signed cookie if applicable
+ * @returns Extracted JWT token
+ */
+const extractToken = (
+  header: string | undefined,
+  signedCookie: string | undefined
+) => {
+  if (header && header.startsWith('Bearer ')) {
+    return header.split(' ')[1];
+  }
+
+  return signedCookie;
+};
+
+/**
+ * Gets the user's status (is normally authenticated and is MFA authenticated).
+ *
+ * @param req - Express.js's request object.
+ * @param res - Express.js's response object.
+ */
+const getStatus = async (req: Request, res: Response) => {
+  let isAuthenticated = true;
+  let isMFA = true;
+
+  try {
+    if (!req.session.userID) {
+      isAuthenticated = false;
+      throw '';
+    }
+
+    // extract token and validate
+    const token = extractToken(
+      req.headers.authorization,
+      req.signedCookies['attendance-jws']
+    );
+    if (!token) {
+      isMFA = false;
+      throw '';
+    }
+
+    // verify token
+    let decoded;
+    try {
+      decoded = await verifyToken(token);
+    } catch {
+      isMFA = false;
+      throw '';
+    }
+
+    // verify JTI
+    if (!decoded.payload.jti) {
+      isMFA = false;
+      throw '';
+    }
+
+    // check if JTI exists in redis
+    const userID = await CacheService.getOTPSession(decoded.payload.jti);
+    if (!userID) {
+      isMFA = false;
+      throw '';
+    }
+
+    // check if user still exists in the database
+    const user = await UserService.getUserByID(userID);
+    if (!user) {
+      isMFA = false;
+      throw '';
+    }
+  } catch {
+    throw '';
+  } finally {
+    sendResponse({
+      req,
+      res,
+      status: 'success',
+      statusCode: 200,
+      data: {
+        isAuthenticated,
+        isMFA,
+      },
+      message: "Successfully fetched the user's status!",
+      type: 'users',
+    });
+  }
+};
+
+export default getStatus;

--- a/api/modules/middleware/has-jwt.ts
+++ b/api/modules/middleware/has-jwt.ts
@@ -1,47 +1,9 @@
 import type { NextFunction, Request, Response } from 'express';
-import * as jose from 'jose';
 
-import config from '../../config';
 import AppError from '../../util/app-error';
+import { extractToken, verifyToken } from '../../util/header-and-jwt';
 import CacheService from '../cache/service';
 import UserService from '../user/service';
-
-/**
- * This function is used to verify the current token from user's cookie.
- * We will also check the supposed 'audience' and 'issuer'.
- *
- * @param token - JWT token
- * @returns A promise object that contains our JWT.
- */
-const verifyToken = async (token: string) => {
-  const publicKey = await jose.importSPKI(config.JWT_PUBLIC_KEY, 'EdDSA');
-
-  const options: jose.JWTVerifyOptions = {
-    audience: config.JWT_AUDIENCE,
-    issuer: config.JWT_ISSUER,
-  };
-
-  return jose.jwtVerify(token, publicKey, options);
-};
-
-/**
- * Extracts a token from either Authorization header or signed cookie.
- * Prioritize token from Authorization header.
- *
- * @param header - Authorization header value
- * @param signedCookie - Signed cookie if applicable
- * @returns Extracted JWT token
- */
-const extractToken = (
-  header: string | undefined,
-  signedCookie: string | undefined
-) => {
-  if (header && header.startsWith('Bearer ')) {
-    return header.split(' ')[1];
-  }
-
-  return signedCookie;
-};
 
 /**
  * Validates whether a user is authorized/authenticated or not (via JWT).

--- a/api/modules/user/handler.ts
+++ b/api/modules/user/handler.ts
@@ -3,6 +3,7 @@ import { validate } from 'express-validation';
 
 import asyncHandler from '../../util/async-handler';
 import getMe from '../middleware/get-me';
+import getStatus from '../middleware/get-status';
 import hasJWT from '../middleware/has-jwt';
 import hasRole from '../middleware/has-role';
 import hasSession from '../middleware/has-session';
@@ -16,6 +17,8 @@ import UserValidation from './validation';
  */
 const UserHandler = () => {
   const handler = express.Router();
+
+  handler.route('/me/status').get(asyncHandler(getStatus));
 
   // restrict below endpoints for people who have logged in
   handler.use(hasSession);

--- a/api/modules/user/handler.ts
+++ b/api/modules/user/handler.ts
@@ -18,7 +18,7 @@ import UserValidation from './validation';
 const UserHandler = () => {
   const handler = express.Router();
 
-  handler.route('/me/status').get(asyncHandler(getStatus));
+  handler.route('/me/status').get(getStatus);
 
   // restrict below endpoints for people who have logged in
   handler.use(hasSession);

--- a/api/util/header-and-jwt.ts
+++ b/api/util/header-and-jwt.ts
@@ -1,0 +1,68 @@
+import * as jose from 'jose';
+
+import config from '../config';
+
+/**
+ * Signs a JWT token with EdDSA algorithm, will transform the JWT into JWS.
+ *
+ * @param jti - Random JSON Token Identifier.
+ * @param userID - A user ID.
+ * @returns Signed JWS.
+ */
+export const signJWS = async (jti: string, userID: string) => {
+  const privateKey = await jose.importPKCS8(config.JWT_PRIVATE_KEY, 'EdDSA');
+
+  const payload: jose.JWTPayload = {
+    aud: config.JWT_AUDIENCE,
+    exp: Math.floor(Date.now() / 1000) + 900, // 15 minutes
+    iat: Math.floor(Date.now() / 1000),
+    iss: config.JWT_ISSUER,
+    jti,
+    nbf: Math.floor(Date.now() / 1000),
+    sub: userID,
+  };
+
+  const headers: jose.JWTHeaderParameters = {
+    alg: 'EdDSA',
+    typ: 'JWT',
+  };
+
+  return new jose.SignJWT(payload).setProtectedHeader(headers).sign(privateKey);
+};
+
+/**
+ * This function is used to verify the current token from user's cookie.
+ * We will also check the supposed 'audience' and 'issuer'.
+ *
+ * @param token - JWT token
+ * @returns A promise object that contains our JWT.
+ */
+export const verifyToken = async (token: string) => {
+  const publicKey = await jose.importSPKI(config.JWT_PUBLIC_KEY, 'EdDSA');
+
+  const options: jose.JWTVerifyOptions = {
+    audience: config.JWT_AUDIENCE,
+    issuer: config.JWT_ISSUER,
+  };
+
+  return jose.jwtVerify(token, publicKey, options);
+};
+
+/**
+ * Extracts a token from either Authorization header or signed cookie.
+ * Prioritize token from Authorization header.
+ *
+ * @param header - Authorization header value
+ * @param signedCookie - Signed cookie if applicable
+ * @returns Extracted JWT token
+ */
+export const extractToken = (
+  header: string | undefined,
+  signedCookie: string | undefined
+) => {
+  if (header && header.startsWith('Bearer ')) {
+    return header.split(' ')[1];
+  }
+
+  return signedCookie;
+};


### PR DESCRIPTION
Implements:

- Middleware to get the current user's authentication status, will return `isAuthenticated` and `isMFA`, to check for ordinary session and secured / OTP session, respectively.
- Move `extractToken`, `signJWS`, and `verifyToken` to `util` folder for reusability.