### PR TITLE
Minor Improvements (Nitpick)

### DIFF
--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -158,11 +158,11 @@ const AuthController = {
     }
 
     // guaranteed to be 'email', 'sms', or 'authenticator' due to the validation layer
-    if (req.params.media === 'email') {
+    if (req.query.media === 'email') {
       // TODO: send email
     }
 
-    if (req.params.media === 'sms') {
+    if (req.query.media === 'sms') {
       // TODO: send sms
     }
 

--- a/api/modules/auth/handler.ts
+++ b/api/modules/auth/handler.ts
@@ -22,19 +22,19 @@ const AuthHandler = () => {
 
   handler.post('/logout', asyncHandler(AuthController.logout));
 
-  handler.put('/otp', hasSession, asyncHandler(AuthController.verifyOTP));
+  handler
+    .route('/otp')
+    .post(
+      hasSession,
+      validate(AuthValidation.sendOTP),
+      asyncHandler(AuthController.sendOTP)
+    )
+    .put(hasSession, asyncHandler(AuthController.verifyOTP));
 
   handler.post(
     '/register',
     validate(AuthValidation.register),
     asyncHandler(AuthController.register)
-  );
-
-  handler.post(
-    '/otp/:media',
-    hasSession,
-    validate(AuthValidation.sendOTP),
-    asyncHandler(AuthController.sendOTP)
   );
 
   return handler;

--- a/api/modules/auth/validation.ts
+++ b/api/modules/auth/validation.ts
@@ -23,9 +23,9 @@ const AuthValidation = {
     }),
   },
 
-  // POST /api/v1/otp/:media
+  // POST /api/v1/otp?media=...
   sendOTP: {
-    params: joi.object().keys({
+    query: joi.object().keys({
       media: joi.string().valid('email', 'sms', 'authenticator').required(),
     }),
   },

--- a/api/modules/error/index.ts
+++ b/api/modules/error/index.ts
@@ -84,6 +84,10 @@ const handleProductionErrors = (err: AppError): AppError => {
       return new AppError('Invalid route parameter(s) for this endpoint!', 400);
     }
 
+    if (err.details.query) {
+      return new AppError(`Field ${err.details.query[0].message}!`, 400);
+    }
+
     if (err.details.body) {
       return new AppError(`Field ${err.details.body[0].message}!`, 400);
     }

--- a/api/util/header-and-jwt.ts
+++ b/api/util/header-and-jwt.ts
@@ -1,4 +1,5 @@
-import * as jose from 'jose';
+import type { JWTHeaderParameters, JWTPayload, JWTVerifyOptions } from 'jose';
+import { importPKCS8, importSPKI, jwtVerify, SignJWT } from 'jose';
 
 import config from '../config';
 
@@ -10,9 +11,9 @@ import config from '../config';
  * @returns Signed JWS.
  */
 export const signJWS = async (jti: string, userID: string) => {
-  const privateKey = await jose.importPKCS8(config.JWT_PRIVATE_KEY, 'EdDSA');
+  const privateKey = await importPKCS8(config.JWT_PRIVATE_KEY, 'EdDSA');
 
-  const payload: jose.JWTPayload = {
+  const payload: JWTPayload = {
     aud: config.JWT_AUDIENCE,
     exp: Math.floor(Date.now() / 1000) + 900, // 15 minutes
     iat: Math.floor(Date.now() / 1000),
@@ -22,12 +23,12 @@ export const signJWS = async (jti: string, userID: string) => {
     sub: userID,
   };
 
-  const headers: jose.JWTHeaderParameters = {
+  const headers: JWTHeaderParameters = {
     alg: 'EdDSA',
     typ: 'JWT',
   };
 
-  return new jose.SignJWT(payload).setProtectedHeader(headers).sign(privateKey);
+  return new SignJWT(payload).setProtectedHeader(headers).sign(privateKey);
 };
 
 /**
@@ -38,14 +39,14 @@ export const signJWS = async (jti: string, userID: string) => {
  * @returns A promise object that contains our JWT.
  */
 export const verifyToken = async (token: string) => {
-  const publicKey = await jose.importSPKI(config.JWT_PUBLIC_KEY, 'EdDSA');
+  const publicKey = await importSPKI(config.JWT_PUBLIC_KEY, 'EdDSA');
 
-  const options: jose.JWTVerifyOptions = {
+  const options: JWTVerifyOptions = {
     audience: config.JWT_AUDIENCE,
     issuer: config.JWT_ISSUER,
   };
 
-  return jose.jwtVerify(token, publicKey, options);
+  return jwtVerify(token, publicKey, options);
 };
 
 /**


### PR DESCRIPTION
Change:

- `POST /auth/otp/:media` to `POST /auth/otp` that accepts query parameters. The new endpoint would be: `POST /auth/otp?media=authenticator`. This is done so `/auth/otp` can be a singleton (in terms of API endpoints), resulting in a more RESTful experience.
- Optimize imports for `jose`.