### PR TITLE
OTP Hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Below is the list of main features that this system have:
 
 - Users can check the health of the API.
 - Users can log in and register.
-- (**A**) Users can see their own profile, modify it, and get their own authentication status.
+- Users can get their own authentication status.
+- (**A**) Users can see their own profile, modify it (except password), and delete it.
+- (**A**) Users can modify their own password.
 - (**A**) Users can get all of their own sessions and can invalidate them if necessary.
 - (**A**) Users can get their own attendance data.
 - (**A**) Users can request OTP from the API via Email, SMS, or Authenticator apps.
@@ -49,12 +51,14 @@ As this research focuses on creating a secure API, below are the considerations 
 - Sessions are signed cookies, implemented with a high-entropy session secret, and served with secure attributes (`secure`, `sameSite`, `httpOnly`). It is regenerated and refreshed in several instances for security.
 - Passwords are hashed with `Argon2` algorithm.
 - The secret to generate the OTP is implemented with `nanoid` (it has high entropy and it is a cryptographically secure generator), and it is different for every other users in the system.
-- OTP is time-based and it is generated with RFC 6238 algorithm with `SHA-1` hash function and a high-entropy secret (above). OTP is verified with the `userID` via RFC 7617 algorithm.
+- Conforms to RFC 6238 and RFC 7617 (TOTP, Basic Authorization).
+- OTP is time-based and it is generated with RFC 6238 algorithm with `SHA-1` hash function and a high-entropy secret (above). OTP is verified with the `userID` via RFC 7617 algorithm. OTPs are for one-time use only (in a certain timeframe).
 - User identification generator is based on `uuidv4` algorithm for low-collision user IDs.
 - Secure API protection middlewares (`helmet`, `hpp`, JSON-only API with a secure parser, slow downs, rate limiters, XST prevention, XSS prevention, and many more).
 - Secure API authorization (session authorization, role-based access control, MFA with JWT/JWS).
 - API logging is performed using `morgan`.
 - API implementation conforms to JSON:API Standard and provides structured error messages and responses according to the best practices.
+- User can be banned by setting their `isActive` attribute to `false`. Banned users cannot access the API.
 - No cheap tricks and 'unusual' security through obscurity (double encryption, triple encoding, multiple hashing, and the like). Cryptography/security is used to serve a specific purpose and be an effective solution for that purpose. Incorrect use of said concepts will make the system to be less secure.
 
 ## Documentation
@@ -153,8 +157,6 @@ Application is licensed under MIT License. The research itself will follow the p
 
 Upcoming features to be implemented:
 
-- Ability for admins to block accounts (`isActive` attribute in Prisma).
-- Special endpoint for credential resets (password change, etc.).
 - Implement front-end with Next.js.
 - SMS implementation.
 - Hosting, webservers, and mailservers.

--- a/api/extensions.d.ts
+++ b/api/extensions.d.ts
@@ -39,6 +39,7 @@ declare module 'express-session' {
       device?: string;
       ip?: string;
     };
+    signedIn?: string;
   }
 }
 

--- a/api/modules/attendance/controller.ts
+++ b/api/modules/attendance/controller.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 
 import AppError from '../../util/app-error';
 import getDeviceID from '../../util/device-id';

--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -221,24 +221,24 @@ const AuthController = {
 
     // Validates whether the username or email or phone is already used or not. Use
     // parallel processing for speed.
-    const users = await Promise.all([
+    const [userByUsername, userByEmail, userByPhone] = await Promise.all([
       UserService.getUser({ username }),
       UserService.getUser({ email }),
       UserService.getUser({ phoneNumber }),
     ]);
 
     // Perform checks and validations.
-    if (users[0]) {
+    if (userByUsername) {
       next(new AppError('This username has existed already!', 400));
       return;
     }
 
-    if (users[1]) {
+    if (userByEmail) {
       next(new AppError('This email has been used by another user!', 400));
       return;
     }
 
-    if (users[2]) {
+    if (userByPhone) {
       next(
         new AppError('This phone number has been used by another user!', 400)
       );

--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -163,6 +163,7 @@ const AuthController = {
       req.session.userRole = user.role;
       req.session.lastActive = Date.now().toString();
       req.session.sessionInfo = getDeviceID(req);
+      req.session.signedIn = Date.now().toString();
 
       // Remove MFA session cookie if it exists.
       res.cookie(config.JWT_COOKIE_NAME, 'loggedOut', { maxAge: 10 });

--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -288,14 +288,14 @@ const AuthController = {
       return;
     }
 
-    // check the availability of the user
+    // Check the availability of the user.
     const user = await UserService.getUserComplete({ userID });
     if (!user) {
       next(new AppError('User with this ID does not exist!', 400));
       return;
     }
 
-    // if not yet expired, means that the user has asked in 'successive' order and it is a potential to spam
+    // If not yet expired, means that the user has asked in 'successive' order and it is a potential to spam.
     if (await CacheService.getHasAskedOTP(userID)) {
       next(
         new AppError(
@@ -306,15 +306,14 @@ const AuthController = {
       return;
     }
 
-    // guaranteed to be 'email', 'sms', or 'authenticator' due to the validation layer
+    // Guaranteed to be 'email', 'sms', or 'authenticator' due to the validation layer.
     const totp = generateDefaultTOTP(user.username, user.totpSecret);
     if (req.query.media === 'email') {
-      // sends an email to the user
       await new Email(user.email, user.fullName).sendOTP(totp.token);
     }
 
+    // TODO: send SMS
     if (req.query.media === 'sms') {
-      // TODO: send sms
       next(
         new AppError(
           'Media is not yet implemented. Please use another media.',
@@ -324,10 +323,10 @@ const AuthController = {
       return;
     }
 
-    // if using authenticator, do nothing as its already there, increment redis instead
+    // If using authenticator, do nothing as its already there, increment redis instead.
     await CacheService.setHasAskedOTP(userID);
 
-    // send back response
+    // Send back response.
     sendResponse({
       req,
       res,
@@ -424,27 +423,27 @@ const AuthController = {
    * @param next - Express.js's next function.
    */
   verifyOTP: async (req: Request, res: Response, next: NextFunction) => {
-    // check headers
+    // Validate header.
     if (!req.headers.authorization) {
       invalidBasicAuth('Missing authorization header!', res, next);
       return;
     }
 
-    // check whether authentication scheme is correct
+    // Check whether authentication scheme is correct.
     const { username, password } = parseBasicAuth(req.headers.authorization);
     if (!username || !password) {
       invalidBasicAuth('Invalid authentication scheme!', res, next);
       return;
     }
 
-    // check whether username exists
+    // Check whether username exists.
     const user = await UserService.getUserComplete({ userID: username });
     if (!user) {
       invalidBasicAuth('User with that identifier is not found.', res, next);
       return;
     }
 
-    // if user has reached 3 times, then block attempt
+    // If user has reached 3 times, then block the user's attempt.
     // TODO: should send email/sms/push notification to the relevant user
     const attempts = await CacheService.getOTPAttempts(user.userID);
     if (attempts && Number.parseInt(attempts, 10) === 3) {
@@ -459,7 +458,15 @@ const AuthController = {
       return;
     }
 
-    // validate otp
+    // Ensures that OTP has never been used before.
+    const usedOTP = await CacheService.getBlacklistedOTP(password);
+    if (usedOTP) {
+      await CacheService.setOTPAttempts(user.userID);
+      invalidBasicAuth('This OTP has expired.', res, next);
+      return;
+    }
+
+    // Validate OTP.
     const validTOTP = validateDefaultTOTP(password, user.totpSecret);
     if (!validTOTP) {
       await CacheService.setOTPAttempts(user.userID);
@@ -467,14 +474,17 @@ const AuthController = {
       return;
     }
 
-    // generate JWS as the authorization ticket
+    // Make sure to blacklist the TOTP (according to the specs).
+    await CacheService.blacklistOTP(password);
+
+    // Generate JWS as the authorization ticket.
     const jti = await nanoid();
     const token = await signJWS(jti, user.userID);
 
-    // set otp session by JTI
+    // Set OTP session by its JTI.
     await CacheService.setOTPSession(jti, user.userID);
 
-    // set cookie
+    // Set cookie for the JWS.
     res.cookie(config.JWT_COOKIE_NAME, token, {
       httpOnly: true,
       secure: req.secure || req.headers['x-forwarded-proto'] === 'https',
@@ -483,7 +493,7 @@ const AuthController = {
       signed: true,
     });
 
-    // send response
+    // Send response.
     sendResponse({
       req,
       res,

--- a/api/modules/cache/repository.ts
+++ b/api/modules/cache/repository.ts
@@ -63,6 +63,15 @@ const allSessions = async () => {
  */
 const CacheRepository = {
   /**
+   * Sets an OTP to be blacklisted in the Redis cache for 120 seconds.
+   *
+   * @param otp - One-time password.
+   * @returns Asynchronous number, response returned from Redis.
+   */
+  blacklistOTP: async (otp: string) =>
+    redis.setex(`blacklisted-otp:${otp}`, 120, 'true'),
+
+  /**
    * Deletes a single session from the cache.
    *
    * @param sessionID - Session identifier.
@@ -81,6 +90,14 @@ const CacheRepository = {
 
     return Promise.all(sessions.map(async (s) => redis.del(`sess:${s.sid}`)));
   },
+
+  /**
+   * Gets an OTP from the Redis cache in order to check if it is blacklisted or not.
+   *
+   * @param otp - One-time password.
+   * @returns Asynchronous number, response returned from Redis.
+   */
+  getBlacklistedOTP: async (otp: string) => redis.get(`blacklisted-otp:${otp}`),
 
   /**
    * Gets whether the user has asked OTP or not.

--- a/api/modules/cache/service.ts
+++ b/api/modules/cache/service.ts
@@ -5,6 +5,14 @@ import CacheRepository from './repository';
  */
 const CacheService = {
   /**
+   * Blacklists an OTP using Redis.
+   *
+   * @param otp - One time password.
+   * @returns Asynchronous number from Redis.
+   */
+  blacklistOTP: async (otp: string) => CacheRepository.blacklistOTP(otp),
+
+  /**
    * Deletes a single session from the cache.
    *
    * @param sessionID - Session ID.
@@ -21,6 +29,15 @@ const CacheService = {
    */
   deleteUserSessions: async (userID: string) =>
     CacheRepository.deleteUserSessions(userID),
+
+  /**
+   * Gets an OTP from the Redis cache in order to know whether it is blacklisted or not.
+   *
+   * @param otp - One time password.
+   * @returns The OTP, or null.
+   */
+  getBlacklistedOTP: async (otp: string) =>
+    CacheRepository.getBlacklistedOTP(otp),
 
   /**
    * Gets whether the user has asked OTP or not.

--- a/api/modules/user/controller.ts
+++ b/api/modules/user/controller.ts
@@ -22,24 +22,24 @@ const UserController = {
 
     // Validates whether the username or email or phone is already used or not. Use
     // parallel processing for speed.
-    const users = await Promise.all([
+    const [userByUsername, userByEmail, userByPhone] = await Promise.all([
       UserService.getUser({ username }),
       UserService.getUser({ email }),
       UserService.getUser({ phoneNumber }),
     ]);
 
     // Perform checks and validations.
-    if (users[0]) {
+    if (userByUsername) {
       next(new AppError('This username has existed already!', 400));
       return;
     }
 
-    if (users[1]) {
+    if (userByEmail) {
       next(new AppError('This email has been used by another user!', 400));
       return;
     }
 
-    if (users[2]) {
+    if (userByPhone) {
       next(
         new AppError('This phone number has been used by another user!', 400)
       );


### PR DESCRIPTION
This PR implements:

- Fix `import` to `import type` in `Attendance` entity.
- Optimize JWT verification by not needing to perform MariaDB calls.
- Add a cache function to blacklist OTPs according to RFC 6238 specifications.
- Update documentation.
- Add destructuring in `Promise.all` function in controller.
- Add new attribute in session: `signedIn` (implemented like GitHub and Google).