### PR TITLE
API HTTP Code and Header Improvements

### DIFF
--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -63,6 +63,19 @@ const AuthController = {
         return;
       }
 
+      // Make sure that the user exists in the database.
+      const user = await UserService.getUser({ userID: req.session.userID });
+      if (!user) {
+        sendUserStatus(req, res, false, false);
+        return;
+      }
+
+      // Make sure that the user is not blocked.
+      if (!user.isActive) {
+        sendUserStatus(req, res, false, false);
+        return;
+      }
+
       // Extract token and validate.
       const token = extractToken(
         req.headers.authorization,
@@ -89,11 +102,10 @@ const AuthController = {
         return;
       }
 
-      // Check if user exists in the database.
-      const user = await UserService.getUser({ userID });
-      if (!user) {
+      // Check if JTI is equal to the current session, and ensure that the subject
+      // is equal to the user ID as well.
+      if (req.session.userID !== userID || decoded.payload.sub !== userID) {
         sendUserStatus(req, res, true, false);
-        return;
       }
 
       // Send final response that the user is properly authenticated and authorized.

--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -218,18 +218,18 @@ const AuthController = {
 
     // Perform checks and validations.
     if (userByUsername) {
-      next(new AppError('This username has existed already!', 400));
+      next(new AppError('This username has existed already!', 422));
       return;
     }
 
     if (userByEmail) {
-      next(new AppError('This email has been used by another user!', 400));
+      next(new AppError('This email has been used by another user!', 422));
       return;
     }
 
     if (userByPhone) {
       next(
-        new AppError('This phone number has been used by another user!', 400)
+        new AppError('This phone number has been used by another user!', 422)
       );
       return;
     }

--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -332,10 +332,10 @@ const AuthController = {
       req,
       res,
       status: 'success',
-      statusCode: 200,
+      statusCode: 202,
       data: [],
       message:
-        'OTP has been processed. Please check your chosen media and verify the OTP there.',
+        'OTP processed. Please check your chosen media and verify the OTP there.',
       type: 'auth',
     });
   },

--- a/api/modules/middleware/has-jwt.ts
+++ b/api/modules/middleware/has-jwt.ts
@@ -6,36 +6,25 @@ import { extractToken, verifyToken } from '../../util/header-and-jwt';
 import CacheService from '../cache/service';
 
 /**
- * Sets the 'WWW-Authenticate' header properly with the right 'Realm'.
- *
- * @param msg - Error message to be passed to the user.
- * @param res - Express.js's response object.
- * @param next - Express.js's next function.
- */
-const invalidBearerAuth = (msg: string, res: Response, next: NextFunction) => {
-  res.set('WWW-Authenticate', 'Bearer realm="OTP-JWS"');
-  next(new AppError(msg, 401));
-};
-
-/**
  * Validates whether a user is authorized/authenticated or not (via JWT).
  * Checks whether the user's session ID exists in Redis.
  *
  * @param req - Express.js's request object.
- * @param res - Express.js's response object.
+ * @param _ - Express.js's response object.
  * @param next - Express.js's next function.
  */
-const hasJWT = async (req: Request, res: Response, next: NextFunction) => {
+const hasJWT = async (req: Request, _: Response, next: NextFunction) => {
   // Extract token and validate.
   const token = extractToken(
     req.headers.authorization,
     req.signedCookies[config.JWT_COOKIE_NAME]
   );
   if (!token) {
-    invalidBearerAuth(
-      'You do not possess an OTP session. Please verify your OTP by MFA.',
-      res,
-      next
+    next(
+      new AppError(
+        'You do not possess an OTP session. Please verify your OTP by MFA.',
+        401
+      )
     );
     return;
   }
@@ -45,10 +34,11 @@ const hasJWT = async (req: Request, res: Response, next: NextFunction) => {
 
   // Verify the token's JTI.
   if (!decoded.payload.jti) {
-    invalidBearerAuth(
-      'The JTI of the token is wrong or does not exist. Please verify your session again.',
-      res,
-      next
+    next(
+      new AppError(
+        'The JTI of the token is invalid. Please verify your session again.',
+        401
+      )
     );
     return;
   }
@@ -56,18 +46,14 @@ const hasJWT = async (req: Request, res: Response, next: NextFunction) => {
   // Check if JTI exists in Redis.
   const userID = await CacheService.getOTPSession(decoded.payload.jti);
   if (!userID) {
-    invalidBearerAuth('This token does not exist in the database.', res, next);
+    next(new AppError('This token does not exist in the database.', 401));
     return;
   }
 
   // Validate whether the session is equal to the user ID + the sub property,
   // there is no need to call the database here (reduces overhead).
   if (req.session.userID !== userID || decoded.payload.sub !== userID) {
-    invalidBearerAuth(
-      'User belonging to this token does not exist.',
-      res,
-      next
-    );
+    next(new AppError('User belonging to this token does not exist.', 404));
     return;
   }
 

--- a/api/modules/user/controller.ts
+++ b/api/modules/user/controller.ts
@@ -30,18 +30,18 @@ const UserController = {
 
     // Perform checks and validations.
     if (userByUsername) {
-      next(new AppError('This username has existed already!', 400));
+      next(new AppError('This username has existed already!', 422));
       return;
     }
 
     if (userByEmail) {
-      next(new AppError('This email has been used by another user!', 400));
+      next(new AppError('This email has been used by another user!', 422));
       return;
     }
 
     if (userByPhone) {
       next(
-        new AppError('This phone number has been used by another user!', 400)
+        new AppError('This phone number has been used by another user!', 422)
       );
       return;
     }


### PR DESCRIPTION
This PR:

- Refine `WWW-Authenticate` header, we do not want the browser prompt after a `401` response.
- Refine email processing, send response first before sending an email for performance.
- Adjust status code to be more semantic: duplicates now return `422`, expired OTPs now return `410`, invalid user in authentication return `404`, sending OTPs now return `202`.
- Refine `getStatus` controller function to be nearly identical with `has-jwt.ts` and `has-session.ts` in `modules/middleware`.