### PR TITLE
Body Parser and Content-Length Refactor

### DIFF
--- a/api/infra/express.ts
+++ b/api/infra/express.ts
@@ -42,8 +42,8 @@ function loadExpress() {
     })
   );
 
-  // Load JSON parser and signed cookie parser.
-  app.use(express.json({ type: 'application/json', limit: '512b' }));
+  // Load signed cookie parser. JSON parser is loaded in each required
+  // endpoints in a case-by-case basis.
   app.use(cookieParser(config.COOKIE_SECRET));
 
   // Prevent parameter pollution.

--- a/api/modules/attendance/handler.ts
+++ b/api/modules/attendance/handler.ts
@@ -3,6 +3,7 @@ import type { RateLimit } from 'express-rate-limit';
 import { validate } from 'express-validation';
 
 import asyncHandler from '../../util/async-handler';
+import bodyParser from '../middleware/body-parser';
 import hasJWT from '../middleware/has-jwt';
 import hasSession from '../middleware/has-session';
 import AttendanceController from './controller';
@@ -29,6 +30,7 @@ const AttendanceHandler = (limiter: RateLimit, strictLimiter: RateLimit) => {
     '/in',
     strictLimiter,
     asyncHandler(hasJWT),
+    bodyParser,
     validate(AttendanceValidation.in),
     asyncHandler(AttendanceController.in)
   );
@@ -38,6 +40,7 @@ const AttendanceHandler = (limiter: RateLimit, strictLimiter: RateLimit) => {
     '/out',
     strictLimiter,
     asyncHandler(hasJWT),
+    bodyParser,
     validate(AttendanceValidation.out),
     asyncHandler(AttendanceController.out)
   );

--- a/api/modules/auth/handler.ts
+++ b/api/modules/auth/handler.ts
@@ -3,6 +3,7 @@ import type { RateLimit } from 'express-rate-limit';
 import { validate } from 'express-validation';
 
 import asyncHandler from '../../util/async-handler';
+import bodyParser from '../middleware/body-parser';
 import hasJWT from '../middleware/has-jwt';
 import hasSession from '../middleware/has-session';
 import AuthController from './controller';
@@ -27,6 +28,7 @@ const AuthHandler = (rateLimit: RateLimit) => {
   // Logs in a single user.
   handler.post(
     '/login',
+    bodyParser,
     validate(AuthValidation.login),
     asyncHandler(AuthController.login)
   );
@@ -47,6 +49,7 @@ const AuthHandler = (rateLimit: RateLimit) => {
   // Registers a single user.
   handler.post(
     '/register',
+    bodyParser,
     validate(AuthValidation.register),
     asyncHandler(AuthController.register)
   );
@@ -63,6 +66,7 @@ const AuthHandler = (rateLimit: RateLimit) => {
   handler.patch(
     '/update-password',
     asyncHandler(hasSession),
+    bodyParser,
     validate(AuthValidation.updatePassword),
     asyncHandler(AuthController.updatePassword)
   );

--- a/api/modules/middleware/body-parser.ts
+++ b/api/modules/middleware/body-parser.ts
@@ -1,0 +1,45 @@
+import type { NextFunction, Request, Response } from 'express';
+import { json } from 'express';
+
+import AppError from '../../util/app-error';
+
+/**
+ * Parses the request body of a request. Do not use this middleware globally. Instead,
+ * use this in requests where you need to parse the request body. This makes the whole API
+ * slightly faster, and saves bandwith / computing powers as well.
+ *
+ * @param req - Express.js's request object.
+ * @param res - Express.js's response object.
+ * @param next - Express.js's next function.
+ * @returns Customized instance of `express.json`, complete with preprocessing.
+ */
+const bodyParser = (req: Request, res: Response, next: NextFunction) => {
+  const { ['content-type']: type, ['content-length']: length } = req.headers;
+
+  // Ensures 'Content-Type' is 'application/json'.
+  if (!type?.includes('application/json')) {
+    next(
+      new AppError(
+        "This API only accepts 'Content-Type' of 'application/json!'",
+        415
+      )
+    );
+    return;
+  }
+
+  // Quick checking: if 'Content-Length' is bigger than the specified bytes,
+  // we will short circuit right away. If the 'Content-Length' is spoofed and the payload
+  // is greater than anticipated, the next `json` function will take care of it accordingly.
+  if (length && Number.parseInt(length, 10) > 512) {
+    next(
+      new AppError('Request is too large! Please reduce your payload!', 413)
+    );
+    return;
+  }
+
+  // We have to `return` this specific middleware as this is an Express middleware, so it can go
+  // straight to the next stack. Simply calling the `json` function will not suffice.
+  return json({ type: 'application/json', limit: 512 })(req, res, next);
+};
+
+export default bodyParser;

--- a/api/modules/user/handler.ts
+++ b/api/modules/user/handler.ts
@@ -4,6 +4,7 @@ import { validate } from 'express-validation';
 
 import asyncHandler from '../../util/async-handler';
 import AttendanceHandler from '../attendance/handler';
+import bodyParser from '../middleware/body-parser';
 import getMe from '../middleware/get-me';
 import hasJWT from '../middleware/has-jwt';
 import hasRole from '../middleware/has-role';
@@ -33,6 +34,7 @@ const UserHandler = (limiter: RateLimit, strictLimiter: RateLimit) => {
     .get(getMe, asyncHandler(UserController.getUser))
     .patch(
       getMe,
+      bodyParser,
       validate(UserValidation.updateMe),
       asyncHandler(UserController.updateUser)
     )
@@ -46,6 +48,7 @@ const UserHandler = (limiter: RateLimit, strictLimiter: RateLimit) => {
     .route('/')
     .get(asyncHandler(UserController.getUsers))
     .post(
+      bodyParser,
       validate(UserValidation.createUser),
       asyncHandler(UserController.createUser)
     );
@@ -55,6 +58,7 @@ const UserHandler = (limiter: RateLimit, strictLimiter: RateLimit) => {
     .route('/:id')
     .get(validate(UserValidation.getUser), asyncHandler(UserController.getUser))
     .patch(
+      bodyParser,
       validate(UserValidation.updateUser),
       asyncHandler(UserController.updateUser)
     )


### PR DESCRIPTION
Implements:

- Removal of a global body parser. A body parser is only used in required endpoints in a case-by-case basis.
- Create custom JSON parser middleware with two preprocesses: `Content-Type` and `Content-Length` checker. This inspiration is drawn from my `asuka` JSON parser for Go.
- Use custom body parser in required endpoints only. This should result in slightly faster connections.