### PR TITLE
Next.js: Content Security Policy

### DIFF
--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -30,8 +30,6 @@ const Layout = ({ children, title }: Props) => (
       <meta name="msapplication-navbutton-color" content="#f67e4d" />
       <meta name="apple-mobile-web-app-status-bar-style" content="#f67e4d" />
 
-      <link rel="icon" href="favicon.png" type="image/png" />
-
       <title>
         {[...title.map((x) => x?.trim()).filter((x) => x), 'Attendance'].join(
           ' · '

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,4 +1,8 @@
-/** @type {import('next').NextConfig} */
+const nextSafe = require('next-safe');
+
+/**
+ * @type {import('next').NextConfig}
+ */
 const nextConfig = {
   // Proxy to back-end in development mode.
   async rewrites() {
@@ -17,34 +21,39 @@ const nextConfig = {
       {
         source: '/:path*',
         headers: [
+          // Send app codename.
           {
             key: 'X-Attendance-Web',
             value: 'Azami',
           },
+
+          // Send app version number.
           {
             key: 'X-Attendance-Web-Version',
-            value: process.env.npm_package_version.toString(),
+            value: process.env.npm_package_version,
           },
+
+          // Allow prefetching.
           {
             key: 'X-DNS-Prefetch-Control',
             value: 'on',
           },
-          {
-            key: 'X-XSS-Protection',
-            value: '1; mode=block',
-          },
-          {
-            key: 'X-Frame-Options',
-            value: 'SAMEORIGIN',
-          },
-          {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
-          },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
-          },
+
+          // Handle secure headers: `Content-Security-Policy`, `Referrer-Policy`,
+          // `X-Content-Type-Options`, `X-Frame-Options`, and `X-XSS-Protection`.
+          ...nextSafe({
+            // Only allow from Google Fonts.
+            contentSecurityPolicy: {
+              'font-src': ["'self'", 'fonts.gstatic.com'],
+              'style-src': ["'self'", 'fonts.googleapis.com'],
+            },
+
+            // `Permissions-Policy` CSP is still experimental.
+            permissionsPolicy: false,
+
+            // Development mode.
+            isDev: process.env.NODE_ENV,
+          }),
         ],
       },
     ];

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "focus-visible": "^5.2.0",
     "framer-motion": "^5",
     "next": "12.0.8",
+    "next-safe": "^3.2.1",
     "qrcode.react": "^1.0.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -33,6 +33,7 @@ const App = ({ Component, pageProps }: AppProps) => {
           heading: `Nunito, ${fallbackFonts}`,
         },
         config: {
+          initialColorMode: 'light',
           useSystemColorMode: true,
         },
       })}

--- a/web/pages/_document.tsx
+++ b/web/pages/_document.tsx
@@ -1,4 +1,3 @@
-import { ColorModeScript } from '@chakra-ui/react';
 import Document, {
   DocumentContext,
   Head,
@@ -33,7 +32,6 @@ class AppDocument extends Document {
           <link rel="shortcut icon" href="favicon.png" type="image/png" />
         </Head>
         <body>
-          <ColorModeScript initialColorMode="system" />
           <Main />
           <NextScript />
         </body>

--- a/web/pages/_document.tsx
+++ b/web/pages/_document.tsx
@@ -30,6 +30,7 @@ class AppDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
             rel="stylesheet"
           />
+          <link rel="shortcut icon" href="favicon.png" type="image/png" />
         </Head>
         <body>
           <ColorModeScript initialColorMode="system" />

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2396,6 +2396,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+next-safe@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/next-safe/-/next-safe-3.2.1.tgz#76bb6deb2b11a39318e5b962a6da4e57584bf77f"
+  integrity sha512-2BBbnendVIlbUjrvV/N6cotuba71i2IIczo0dqmpZu9oSl2PlN6hYML22fidcqXZILwghyXULIy4lxyAgPz+Xg==
+
 next@12.0.8:
   version "12.0.8"
   resolved "https://registry.yarnpkg.com/next/-/next-12.0.8.tgz#29138f7cdd045e4bbba466af45bf430e769634b4"


### PR DESCRIPTION
Implements:

- Secure headers: `X-DNS-Prefetch-Control`, `Content-Security-Policy`, `Referrer-Policy`, `X-Content-Type-Options`, `X-Frame-Options`, and `X-XSS-Protection`.
- Identifying headers: `X-Attendance-Web`, `X-Attendance-Web-Version`.
- The `Content-Security-Policy` comes from `next-safe` and it is super strict. That's why Chakra's `<ColorModeScript />` has to be removed for now.
- Move `shortcut icon` / `favicon` to document level to prevent `404 Not Found` in browsers.