### PR TITLE
Harden Cookie Security (`__Host-` prefix)

### DIFF
--- a/api/modules/middleware/session.ts
+++ b/api/modules/middleware/session.ts
@@ -20,11 +20,17 @@ const session = () => (req: Request, res: Response, next: NextFunction) => {
     sameSite: 'strict',
     maxAge: 7200 * 1000, // 2 hours that will be refreshed every time the user hits a 'has-session' middleware.
     secure: isHTTPS(req), // Use 'secure' on production environment.
+    path: '/', // Send in every requests.
   };
+
+  // Use '__Host-' prefix on cookie name in production.
+  const cookie = isHTTPS(req)
+    ? `__Host-${config.SESSION_COOKIE}`
+    : config.SESSION_COOKIE;
 
   return expressSession({
     store: new RedisSessionStore({ client: redis.nodeRedis }),
-    name: config.SESSION_COOKIE,
+    name: cookie,
     saveUninitialized: false,
     resave: false,
     secret: config.COOKIE_SECRET,


### PR DESCRIPTION
According to OWASP, one additional way to secure a cookie (instead of just using `httpOnly`, `secure`, and `sameSite` set to `strict`) is to add ` __Host-` prefix. This ensures that the cookie will never be overwritten by subdomains and or other scripts, and ensures that only the server can set or revoke the cookie accordingly.

References:
- [OWASP ASVS](https://github.com/OWASP/ASVS)
- [OWASP Session Management - Testing for Cookie Attributes](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/06-Session_Management_Testing/02-Testing_for_Cookies_Attributes)