### PR TITLE
Revision of `X-Powered-By` Header

### DIFF
--- a/api/infra/bull.ts
+++ b/api/infra/bull.ts
@@ -1,4 +1,4 @@
-import { ConnectionOptions, Job } from 'bullmq';
+import type { ConnectionOptions, Job } from 'bullmq';
 import { Queue, Worker } from 'bullmq';
 
 import config from '../config';

--- a/api/infra/express.ts
+++ b/api/infra/express.ts
@@ -14,6 +14,7 @@ import { errorLogger, successLogger } from '../modules/middleware/logger';
 import notFound from '../modules/middleware/not-found';
 import session from '../modules/middleware/session';
 import slowDown from '../modules/middleware/slow-down';
+import xPoweredBy from '../modules/middleware/x-powered-by';
 import xst from '../modules/middleware/xst';
 import SessionHandler from '../modules/session/handler';
 import UserHandler from '../modules/user/handler';
@@ -36,6 +37,7 @@ function loadExpress() {
       frameguard: {
         action: 'deny',
       },
+      hidePoweredBy: false,
     })
   );
 
@@ -61,6 +63,9 @@ function loadExpress() {
 
   // Prepare to use Express Sessions.
   app.use(session());
+
+  // Enable special `X-Powered-By` header.
+  app.use(xPoweredBy());
 
   // Define handlers.
   const attendanceHandler = AttendanceHandler();

--- a/api/modules/attendance/handler.ts
+++ b/api/modules/attendance/handler.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import { Router } from 'express';
 import { validate } from 'express-validation';
 
 import asyncHandler from '../../util/async-handler';
@@ -15,7 +15,7 @@ import AttendanceValidation from './validation';
  * @returns Express router.
  */
 const AttendanceHandler = () => {
-  const handler = express.Router({ mergeParams: true });
+  const handler = Router({ mergeParams: true });
   const attendanceRateLimit = rateLimit(15, 'attendance-check');
 
   // Endpoints are only for authenticated users,

--- a/api/modules/auth/handler.ts
+++ b/api/modules/auth/handler.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import { Router } from 'express';
 import { validate } from 'express-validation';
 
 import asyncHandler from '../../util/async-handler';
@@ -16,7 +16,7 @@ import AuthValidation from './validation';
  * @returns Express router.
  */
 const AuthHandler = () => {
-  const handler = express.Router();
+  const handler = Router();
   const authRateLimit = rateLimit(10, 'auth');
 
   // General endpoint, (almost) no rate limit.

--- a/api/modules/health/handler.ts
+++ b/api/modules/health/handler.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import express from 'express';
+import { Router } from 'express';
 
 import sendResponse from '../../util/send-response';
 
@@ -9,7 +9,7 @@ import sendResponse from '../../util/send-response';
  * @returns Express router.
  */
 const HealthHandler = () => {
-  const router = express();
+  const router = Router();
 
   /**
    * Checks the health of the service.

--- a/api/modules/middleware/x-powered-by.ts
+++ b/api/modules/middleware/x-powered-by.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 
 /**
  * Override `X-Powered-By` with some other string.

--- a/api/modules/middleware/x-powered-by.ts
+++ b/api/modules/middleware/x-powered-by.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response } from 'express';
+
+/**
+ * Override `X-Powered-By` with some other string.
+ *
+ * @returns Middleware function to override `X-Powered-By`.
+ */
+const xPoweredBy = () => (_: Request, res: Response, next: NextFunction) => {
+  res.setHeader('X-Powered-By', 'Nicholas');
+  next();
+};
+
+export default xPoweredBy;

--- a/api/modules/session/handler.ts
+++ b/api/modules/session/handler.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import { Router } from 'express';
 import { validate } from 'express-validation';
 
 import asyncHandler from '../../util/async-handler';
@@ -15,7 +15,7 @@ import SessionValidation from './validation';
  * @returns Express router.
  */
 const SessionHandler = () => {
-  const handler = express.Router();
+  const handler = Router();
 
   // Allow rate limiters.
   handler.use(rateLimit(100, 'sessions'));

--- a/api/modules/user/handler.ts
+++ b/api/modules/user/handler.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import { Router } from 'express';
 import { validate } from 'express-validation';
 
 import asyncHandler from '../../util/async-handler';
@@ -18,7 +18,7 @@ import UserValidation from './validation';
  * @returns Express router.
  */
 const UserHandler = () => {
-  const handler = express.Router();
+  const handler = Router();
   const userRateLimit = rateLimit(100, 'users-me', 15);
   const adminRateLimit = rateLimit(30, 'users-admin');
 

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -69,6 +69,9 @@ const nextConfig = {
     ];
   },
 
+  // Disable `X-Powered-By` header.
+  poweredByHeader: false,
+
   // Enable minification.
   swcMinify: true,
 


### PR DESCRIPTION
PR implements:

- Override for `X-Powered-By` header in API. According to OWASP, `X-Powered-By` should be hidden if possible, but it is not a critical vulnerability and might even be unnecessary as well.
- Do not import `express` in `modules/*/handler.ts`. Instead, do `import { Router } from 'express'`.
- Remove `X-Powered-By` header in Next.js front-end.
- Fix `import` to `import type`.