### PR TITLE
Validate Accept Header: `406 Unacceptable`

### DIFF
--- a/api/infra/express.ts
+++ b/api/infra/express.ts
@@ -9,6 +9,7 @@ import AttendanceHandler from '../modules/attendance/handler';
 import AuthHandler from '../modules/auth/handler';
 import errorHandler from '../modules/error';
 import HealthHandler from '../modules/health/handler';
+import accept from '../modules/middleware/accept';
 import busyHandler from '../modules/middleware/busy-handler';
 import favicon from '../modules/middleware/favicon';
 import { errorLogger, successLogger } from '../modules/middleware/logger';
@@ -42,6 +43,12 @@ function loadExpress() {
     })
   );
 
+  // Enable special `X-Powered-By` header.
+  app.use(xPoweredBy());
+
+  // Validate `Accept` header.
+  app.use(accept());
+
   // Handle if server is too busy.
   app.use(busyHandler());
 
@@ -67,9 +74,6 @@ function loadExpress() {
 
   // Prepare to use Express Sessions.
   app.use(session());
-
-  // Enable special `X-Powered-By` header.
-  app.use(xPoweredBy());
 
   // Define handlers.
   const attendanceHandler = AttendanceHandler();

--- a/api/modules/middleware/accept.ts
+++ b/api/modules/middleware/accept.ts
@@ -1,0 +1,25 @@
+import type { NextFunction, Request, Response } from 'express';
+
+import AppError from '../../util/app-error';
+
+/**
+ * Middleware to validate the `Accept` header in the API.
+ *
+ * @returns Middleware to validate the `Accept` header.
+ */
+const accept = () => (req: Request, _: Response, next: NextFunction) => {
+  const { accept } = req.headers;
+
+  // If the request do not `Accept` available formats, deny the request.
+  if (
+    !accept?.includes('application/json') &&
+    !accept?.includes('application/vnd.nicholasdw.v1+json')
+  ) {
+    next(new AppError('API does not support the requested content type.', 406));
+    return;
+  }
+
+  next();
+};
+
+export default accept;

--- a/api/modules/middleware/body-parser.ts
+++ b/api/modules/middleware/body-parser.ts
@@ -43,7 +43,7 @@ const bodyParser = (req: Request, res: Response, next: NextFunction) => {
 
   // Quick checking: if 'Content-Length' is bigger than the specified bytes,
   // we will short circuit right away. If the 'Content-Length' is spoofed and the payload
-  // is greater than anticipated, the next `json` function will take care of it accordingly.
+  // is greater than anticipated, the next `parse` function will take care of it accordingly.
   if (length && Number.parseInt(length, 10) > 512) {
     next(
       new AppError('Request is too large! Please reduce your payload!', 413)
@@ -52,7 +52,7 @@ const bodyParser = (req: Request, res: Response, next: NextFunction) => {
   }
 
   // We have to `return` this specific middleware as this is an Express middleware, so it can go
-  // straight to the next stack. Simply calling the `json` function will not suffice.
+  // straight to the next stack. Simply calling the `parse` function will not suffice.
   return parse({ type: json, limit: 512 })(req, res, next);
 };
 

--- a/api/modules/middleware/body-parser.ts
+++ b/api/modules/middleware/body-parser.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from 'express';
-import { json } from 'express';
+import { json as parse } from 'express';
 
 import AppError from '../../util/app-error';
 
@@ -14,7 +14,21 @@ import AppError from '../../util/app-error';
  * @returns Customized instance of `express.json`, complete with preprocessing.
  */
 const bodyParser = (req: Request, res: Response, next: NextFunction) => {
-  const { ['content-type']: type, ['content-length']: length } = req.headers;
+  const {
+    ['content-type']: type,
+    ['content-length']: length,
+    accept,
+  } = req.headers;
+
+  // Declare allowed 'Accept' and 'Content-Type'.
+  const json = 'application/json';
+  const vendor = 'application/vnd.nicholasdw.v1+json';
+
+  // If the request do not `Accept` available formats, deny the request.
+  if (!accept?.includes(json) && !accept?.includes(vendor)) {
+    next(new AppError('API does not accept the requested content type.', 406));
+    return;
+  }
 
   // Ensures 'Content-Type' is 'application/json'.
   if (!type?.includes('application/json')) {
@@ -39,7 +53,7 @@ const bodyParser = (req: Request, res: Response, next: NextFunction) => {
 
   // We have to `return` this specific middleware as this is an Express middleware, so it can go
   // straight to the next stack. Simply calling the `json` function will not suffice.
-  return json({ type: 'application/json', limit: 512 })(req, res, next);
+  return parse({ type: json, limit: 512 })(req, res, next);
 };
 
 export default bodyParser;

--- a/api/modules/middleware/body-parser.ts
+++ b/api/modules/middleware/body-parser.ts
@@ -14,21 +14,7 @@ import AppError from '../../util/app-error';
  * @returns Customized instance of `express.json`, complete with preprocessing.
  */
 const bodyParser = (req: Request, res: Response, next: NextFunction) => {
-  const {
-    ['content-type']: type,
-    ['content-length']: length,
-    accept,
-  } = req.headers;
-
-  // Declare allowed 'Accept' and 'Content-Type'.
-  const json = 'application/json';
-  const vendor = 'application/vnd.nicholasdw.v1+json';
-
-  // If the request do not `Accept` available formats, deny the request.
-  if (!accept?.includes(json) && !accept?.includes(vendor)) {
-    next(new AppError('API does not accept the requested content type.', 406));
-    return;
-  }
+  const { ['content-type']: type, ['content-length']: length } = req.headers;
 
   // Ensures 'Content-Type' is 'application/json'.
   if (!type?.includes('application/json')) {
@@ -53,7 +39,7 @@ const bodyParser = (req: Request, res: Response, next: NextFunction) => {
 
   // We have to `return` this specific middleware as this is an Express middleware, so it can go
   // straight to the next stack. Simply calling the `parse` function will not suffice.
-  return parse({ type: json, limit: 512 })(req, res, next);
+  return parse({ type: 'application/json', limit: 512 })(req, res, next);
 };
 
 export default bodyParser;


### PR DESCRIPTION
This PR validates the `Accept` header of the request. If the API receives an `Accept` header other than `application/json` or `application/vnd.nicholasdw.v1+json` (or if the `Accept` header is empty or `*/*`), then the API will throw a `406 Unacceptable`.