### PR TITLE
CSRF Prevention: `X-Requested-With` Header

### DIFF
--- a/api/infra/express.ts
+++ b/api/infra/express.ts
@@ -16,6 +16,7 @@ import notFound from '../modules/middleware/not-found';
 import session from '../modules/middleware/session';
 import slowDown from '../modules/middleware/slow-down';
 import xPoweredBy from '../modules/middleware/x-powered-by';
+import xRequestedWith from '../modules/middleware/x-requested-with';
 import xst from '../modules/middleware/xst';
 import SessionHandler from '../modules/session/handler';
 import UserHandler from '../modules/user/handler';
@@ -31,6 +32,9 @@ function loadExpress() {
   if (config.NODE_ENV === 'production') {
     app.enable('trust proxy');
   }
+
+  // Check for CSRF via the Header method.
+  app.use(xRequestedWith());
 
   // Security headers.
   app.use(

--- a/api/modules/middleware/logger.ts
+++ b/api/modules/middleware/logger.ts
@@ -29,7 +29,7 @@ const options: LoggerOptions = {
   dynamicMeta: (req) => ({ deviceInfo: getDeviceID(req) }),
 
   // Customized message attribute in logging.
-  msg: 'HTTP {{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}',
+  msg: 'HTTP {{req.method}} {{req.url}}',
 
   // Deactivate both colorization and Express Format, we have our own format.
   expressFormat: false,

--- a/api/modules/middleware/x-requested-with.ts
+++ b/api/modules/middleware/x-requested-with.ts
@@ -1,0 +1,33 @@
+import type { NextFunction, Request, Response } from 'express';
+
+import AppError from '../../util/app-error';
+
+/**
+ * If consumer does not pass the `X-Requested-With` header, then
+ * we can assume that the request is forged with CSRF. `X-Requested-With`
+ * will force requests to enter preflight state first before accessing the API. As
+ * long as the CORS policy is strong, CSRF should be mitigated completely.
+ *
+ * References:
+ * {@link https://stackoverflow.com/questions/17478731/whats-the-point-of-the-x-requested-with-header}
+ * {@link https://markitzeroday.com/x-requested-with/cors/2017/06/29/csrf-mitigation-for-ajax-requests.html}
+ * {@link https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#use-of-custom-request-headers}
+ *
+ * @returns Middleware function to check for `X-Requested-With` header.
+ */
+const xRequestedWith =
+  () => (req: Request, _: Response, next: NextFunction) => {
+    if (!req.headers['x-requested-with']) {
+      next(
+        new AppError(
+          'Access denied as the request is possibly tampered with a possible attempt to perform CSRF in the API.',
+          403
+        )
+      );
+      return;
+    }
+
+    next();
+  };
+
+export default xRequestedWith;

--- a/api/modules/middleware/x-requested-with.ts
+++ b/api/modules/middleware/x-requested-with.ts
@@ -20,7 +20,7 @@ const xRequestedWith =
     if (!req.headers['x-requested-with']) {
       next(
         new AppError(
-          'Access denied as the request is possibly tampered with a possible attempt to perform CSRF in the API.',
+          'This API does not accept cross-site requests with browser agents unless from an authorized source.',
           403
         )
       );

--- a/web/utils/http.ts
+++ b/web/utils/http.ts
@@ -10,6 +10,7 @@ const instance = axiosClient.create({
   headers: {
     Accept: 'application/vnd.nicholasdw.v1+json',
     'Content-Type': 'application/json; charset=utf-8',
+    'X-Requested-With': 'axios',
   },
 });
 


### PR DESCRIPTION
According to OWASP, one of the ways to prevent CSRF attacks is to validate the `X-Requested-With` header. It is not able to be sent cross-domains, and will trigger a preflight request. If someone does not send the `X-Requested-With` header, the request will be rejected with `403 Forbidden`.

This PR also fixes the `message` attribute in `logger.ts`, and at the same time, also injects `X-Requested-With` in the default `axios` instance in `web/utils/http.ts`.