### PR TITLE
Attendances and Session Minor Improvements

### DIFF
--- a/api/core/rfc6238.ts
+++ b/api/core/rfc6238.ts
@@ -82,7 +82,7 @@ export const validateDefaultTOTP = (token: string, secret: string) => {
     secret: otpSecret,
   });
 
-  // Allow delta up to 2 (technically 120 seconds) in time drift.
+  // Allow delta up to 2 (technically 90 seconds) in time drift.
   const delta = totp.validate({ token, window: 2 });
   if (delta === null) {
     return false;

--- a/api/extensions.d.ts
+++ b/api/extensions.d.ts
@@ -1,7 +1,6 @@
 declare module 'express-session' {
   interface SessionData {
     userID?: string;
-    userRole?: string;
     lastActive?: string;
     sessionInfo?: {
       device?: string;

--- a/api/infra/express.ts
+++ b/api/infra/express.ts
@@ -92,7 +92,7 @@ function loadExpress() {
   // Define API routes. Throttle '/api' route to prevent spammers.
   app.use('/api', slowDown(75));
   app.use('/api/v1', healthHandler);
-  app.use('/api/v1/attendance', attendanceHandler);
+  app.use('/api/v1/attendances', attendanceHandler);
   app.use('/api/v1/auth', authHandler);
   app.use('/api/v1/sessions', sessionHandler);
   app.use('/api/v1/users', userHandler);

--- a/api/modules/attendance/controller.ts
+++ b/api/modules/attendance/controller.ts
@@ -66,6 +66,41 @@ const AttendanceController = {
   },
 
   /**
+   * Gets all attendances of a single user by their session ID.
+   *
+   * @param req - Express.js's request object.
+   * @param res - Express.js's response object.
+   * @param next - Express.js's next function.
+   */
+  getMyAttendances: async (req: Request, res: Response, next: NextFunction) => {
+    const { userID } = req.session;
+
+    if (!userID) {
+      next(new AppError('No session detected. Please log in again!', 401));
+      return;
+    }
+
+    const user = await UserService.getUserComplete({ userID });
+    if (!user) {
+      next(new AppError('User with this ID is not found.', 404));
+      return;
+    }
+
+    const attendances = await AttendanceService.getAttendances({
+      userPK: user.userPK,
+    });
+    sendResponse({
+      req,
+      res,
+      status: 'success',
+      statusCode: 200,
+      data: attendances,
+      message: 'Successfully fetched attendance data for a single user!',
+      type: 'attendance',
+    });
+  },
+
+  /**
    * Gets the attendance status of the current user.
    *
    * @param req - Express.js's request object.

--- a/api/modules/attendance/handler.ts
+++ b/api/modules/attendance/handler.ts
@@ -56,7 +56,7 @@ const AttendanceHandler = () => {
   // Gets all attendances data.
   handler.get(
     '/',
-    hasRole('admin'),
+    asyncHandler(hasRole('admin')),
     validate(AttendanceValidation.getAttendances),
     asyncHandler(AttendanceController.getAttendances)
   );

--- a/api/modules/attendance/handler.ts
+++ b/api/modules/attendance/handler.ts
@@ -4,6 +4,7 @@ import { validate } from 'express-validation';
 import asyncHandler from '../../util/async-handler';
 import bodyParser from '../middleware/body-parser';
 import hasJWT from '../middleware/has-jwt';
+import hasRole from '../middleware/has-role';
 import hasSession from '../middleware/has-session';
 import rateLimit from '../middleware/rate-limit';
 import AttendanceController from './controller';
@@ -16,6 +17,7 @@ import AttendanceValidation from './validation';
  */
 const AttendanceHandler = () => {
   const handler = Router({ mergeParams: true });
+  const userAttendanceRateLimit = rateLimit(100, 'attendance-me');
   const attendanceRateLimit = rateLimit(15, 'attendance-check');
 
   // Endpoints are only for authenticated users,
@@ -44,9 +46,17 @@ const AttendanceHandler = () => {
     asyncHandler(AttendanceController.out)
   );
 
+  // Get personal attendance data.
+  handler.get(
+    '/me',
+    userAttendanceRateLimit,
+    asyncHandler(AttendanceController.getMyAttendances)
+  );
+
   // Gets all attendances data.
   handler.get(
     '/',
+    hasRole('admin'),
     validate(AttendanceValidation.getAttendances),
     asyncHandler(AttendanceController.getAttendances)
   );

--- a/api/modules/attendance/validation.ts
+++ b/api/modules/attendance/validation.ts
@@ -4,21 +4,21 @@ import joi from '../../util/joi';
  * Special attendance validations to sanitize and analyze request bodies and parameters.
  */
 const AttendanceValidation = {
-  // GET /api/v1/attendance and/or /api/v1/users/{id}/attendance
+  // GET /api/v1/attendances and/or /api/v1/users/{id}/attendances
   getAttendances: {
     params: joi.object().keys({
       id: joi.string().guid({ version: ['uuidv4'] }),
     }),
   },
 
-  // POST /api/v1/attendance/in
+  // POST /api/v1/attendances/in
   in: {
     body: joi.object().keys({
       remarksEnter: joi.string().trim().max(100),
     }),
   },
 
-  // PATCH /api/v1/attendance/out
+  // PATCH /api/v1/attendances/out
   out: {
     body: joi.object().keys({
       remarksLeave: joi.string().trim().max(100),

--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -177,7 +177,6 @@ const AuthController = {
 
       // Set signed cookies with session information.
       req.session.userID = user.userID;
-      req.session.userRole = user.role;
       req.session.lastActive = Date.now().toString();
       req.session.sessionInfo = getDeviceID(req);
       req.session.signedIn = Date.now().toString();

--- a/api/modules/middleware/logger.ts
+++ b/api/modules/middleware/logger.ts
@@ -42,7 +42,7 @@ const options = (filename: string): LoggerOptions => ({
   headerBlacklist: ['authorization', 'cookie'],
 
   // Ignore frequently called routes via SWR.
-  ignoredRoutes: ['/api/v1/auth/status', '/api/v1/attendance/status'],
+  ignoredRoutes: ['/api/v1/auth/status', '/api/v1/attendances/status'],
 
   // Log everything.
   requestWhitelist: [

--- a/api/modules/session/handler.ts
+++ b/api/modules/session/handler.ts
@@ -37,7 +37,7 @@ const SessionHandler = () => {
     );
 
   // Only allow administrators.
-  handler.use(hasRole('admin'));
+  handler.use(asyncHandler(hasRole('admin')));
 
   // Only allow session checking and session invalidation (admins).
   handler.route('/').get(asyncHandler(SessionController.getAllSessions));

--- a/api/modules/user/handler.ts
+++ b/api/modules/user/handler.ts
@@ -42,7 +42,11 @@ const UserHandler = () => {
     .delete(getMe, asyncHandler(UserController.deactivateUser));
 
   // Restrict endpoints for admins who are logged in and authenticated with MFA.
-  handler.use(adminRateLimit, hasRole('admin'), asyncHandler(hasJWT));
+  handler.use(
+    adminRateLimit,
+    asyncHandler(hasRole('admin')),
+    asyncHandler(hasJWT)
+  );
 
   // Perform get and create operations on the general entity.
   handler

--- a/api/modules/user/handler.ts
+++ b/api/modules/user/handler.ts
@@ -23,7 +23,7 @@ const UserHandler = () => {
   const adminRateLimit = rateLimit(30, 'users-admin');
 
   // Route to 'Attendance' entity based on the current user for better REST-ful experience.
-  handler.use('/:id/attendance', AttendanceHandler());
+  handler.use('/:id/attendances', AttendanceHandler());
 
   // Below endpoints are allowed for only authenticated users.
   handler.use(asyncHandler(hasSession));

--- a/web/components/Overlay/AttendanceModal.tsx
+++ b/web/components/Overlay/AttendanceModal.tsx
@@ -71,7 +71,7 @@ const AttendanceModal = ({
     setIsLoading(true);
     axios({
       method: isIn ? 'POST' : 'PATCH',
-      url: `/api/v1/attendance/${isIn ? 'in' : 'out'}`,
+      url: `/api/v1/attendances/${isIn ? 'in' : 'out'}`,
       data,
     })
       .then((res) => {

--- a/web/components/Overlay/AttendanceModal.tsx
+++ b/web/components/Overlay/AttendanceModal.tsx
@@ -20,6 +20,7 @@ import { FaBolt, FaCube } from 'react-icons/fa';
 import type { KeyedMutator } from 'swr';
 
 import axios from '../../utils/http';
+import type { AttendanceStatus } from '../../utils/types';
 import { SuccessToast } from '../Toast';
 
 /**
@@ -29,10 +30,7 @@ type Props = {
   isOpen: boolean;
   onClose: () => void;
   isIn: boolean;
-  setAttendanceStatus: KeyedMutator<{
-    hasCheckedIn: boolean;
-    hasCheckedOut: boolean;
-  }>;
+  setAttendanceStatus: KeyedMutator<AttendanceStatus>;
 };
 
 /**

--- a/web/components/Overlay/OTPModal.tsx
+++ b/web/components/Overlay/OTPModal.tsx
@@ -18,7 +18,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { memo, useEffect, useState } from 'react';
-import { FaGoogle, FaMagic, FaMailBulk, FaSms, FaTimes } from 'react-icons/fa';
+import { FaGoogle, FaMagic, FaMailBulk, FaTimes } from 'react-icons/fa';
 
 import { useStatusAndUser } from '../../utils/hooks';
 import axios from '../../utils/http';
@@ -54,14 +54,15 @@ const OTPModal = ({ isOpen, onClose, user }: Props) => {
   useEffect(() => {
     const ctrUpdate = setInterval(() => {
       if (counter === 0) {
-        clearInterval(ctrUpdate);
-        return;
+        return () => clearInterval(ctrUpdate);
       }
 
       setCounter((ctr) => ctr - 1);
     }, 1000);
 
-    return () => clearInterval(ctrUpdate);
+    return () => {
+      clearInterval(ctrUpdate);
+    };
   }, [counter]);
 
   // Sends an OTP.
@@ -102,7 +103,6 @@ const OTPModal = ({ isOpen, onClose, user }: Props) => {
         // Mutate the data without revalidation.
         mutate({ isAuthenticated: true, isMFA: true, user }, false);
       })
-      .then(onClose)
       .catch((err) => {
         setFlash({ type: 'error', message: err.message });
         setIsVerifyLoading(false);

--- a/web/utils/hooks.ts
+++ b/web/utils/hooks.ts
@@ -36,7 +36,7 @@ export const useRequest = <T>(key: Key) => {
  */
 export const useAttendances = () => {
   const { data, error, mutate } = useSWR<Attendance[]>(
-    '/api/v1/attendance',
+    '/api/v1/attendances',
     fetcher
   );
 
@@ -58,7 +58,7 @@ export const useAttendanceStatus = () => {
   const { data, error, mutate } = useSWR<{
     hasCheckedIn: boolean;
     hasCheckedOut: boolean;
-  }>(status?.isAuthenticated && '/api/v1/attendance/status', fetcher);
+  }>(status?.isAuthenticated && '/api/v1/attendances/status', fetcher);
 
   return {
     attendanceStatus: data,
@@ -110,7 +110,7 @@ export const useMe = () => {
     mutate: mutateAttendance,
   } = useSWR<Attendance[]>(
     status?.isAuthenticated && status.user
-      ? `/api/v1/users/${status.user.userID}/attendance`
+      ? `/api/v1/users/${status.user.userID}/attendances`
       : null,
     fetcher
   );

--- a/web/utils/hooks.ts
+++ b/web/utils/hooks.ts
@@ -2,7 +2,13 @@ import type { Key } from 'swr';
 import useSWR from 'swr';
 
 import { fetcher } from './http';
-import type { Attendance, Session, Status, User } from './types';
+import type {
+  Attendance,
+  AttendanceStatus,
+  Session,
+  Status,
+  User,
+} from './types';
 
 /**
  * Hook to call a `GET` request with Vercel's `useSWR` for performance and reactive
@@ -55,10 +61,10 @@ export const useAttendances = () => {
  */
 export const useAttendanceStatus = () => {
   const { status } = useStatusAndUser();
-  const { data, error, mutate } = useSWR<{
-    hasCheckedIn: boolean;
-    hasCheckedOut: boolean;
-  }>(status?.isAuthenticated && '/api/v1/attendances/status', fetcher);
+  const { data, error, mutate } = useSWR<AttendanceStatus>(
+    status?.isAuthenticated && '/api/v1/attendances/status',
+    fetcher
+  );
 
   return {
     attendanceStatus: data,

--- a/web/utils/hooks.ts
+++ b/web/utils/hooks.ts
@@ -109,9 +109,7 @@ export const useMe = () => {
     error: attendanceError,
     mutate: mutateAttendance,
   } = useSWR<Attendance[]>(
-    status?.isAuthenticated && status.user
-      ? `/api/v1/users/${status.user.userID}/attendances`
-      : null,
+    status?.isAuthenticated && status.user ? `/api/v1/attendances/me` : null,
     fetcher
   );
 

--- a/web/utils/routes.ts
+++ b/web/utils/routes.ts
@@ -14,7 +14,6 @@ const routes = {
   users: '/admin/users',
 
   // Utility routes.
-  sitemap: '/sitemap.xml',
   robots: '/robots.txt',
   notFound: '/404',
   notAuthorized: '/401',

--- a/web/utils/types.ts
+++ b/web/utils/types.ts
@@ -60,7 +60,6 @@ export type Status = {
  */
 export type Session = {
   userID: string;
-  userRole: 'admin' | 'user';
   lastActive: string;
   sessionInfo: {
     device: string;


### PR DESCRIPTION
Implements:

- Implement specific route to get own attendances: `/api/v1/attendances/me`.
- General endpoints for attendances, `/api/v1/attendances` and `/api/v1/users/:id/attendances` are restricted for administrators.
- Fix JSDoc comment in `core/rfc6238.ts`, it should be 90 seconds instead of 120 seconds.
- Fix memory leak on closing OTP modal.
- Use `AttendanceStatus` instead of hardcoding, and remove `sitemap.xml` in `routes.ts`.
- Prevent stale roles and optimize session by removing `userRole` from session.
- Wrap `has-role.ts` middlewares in `asyncHandler`.