### PR TITLE
Mobile: Minor Rendering Fixes

### DIFF
--- a/web/components/Overlay/QRDialog.tsx
+++ b/web/components/Overlay/QRDialog.tsx
@@ -69,7 +69,6 @@ const QRDialog = ({
         closeOnEsc={false}
         closeOnOverlayClick={false}
         size="3xl"
-        isCentered
       >
         <AlertDialogOverlay>
           <AlertDialogContent bg="white" color="black">

--- a/web/components/Pages/Profile/Passwordbox.tsx
+++ b/web/components/Pages/Profile/Passwordbox.tsx
@@ -44,14 +44,14 @@ const Passwordbox = () => {
         // Set is loading to false.
         setIsLoading(false);
 
-        // Replace router with login.
-        router.replace(routes.login);
-
         // Mutate session and force user to log out.
         mutate({ isAuthenticated: false, isMFA: false, user: null }, false);
 
         // Spawn modal.
         SuccessToast(toast, res.message);
+
+        // Replace router with login.
+        router.replace(routes.login);
       })
       .catch((err) => {
         FailedToast(toast, err.message);


### PR DESCRIPTION
Fixes:

- `QRDialog` being too large because of the `isCentered` prop in mobile devices. Said prop has been removed for convenience.
- `Passwordbox` now redirects to the login page instead of being stuck at `401 Unauthorized` page.