### PR TITLE
Minor Adjustments

### DIFF
--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -138,8 +138,8 @@ const AuthController = {
 
     // Try to find user by both attributes.
     const [userByUsername, userByEmail] = await Promise.all([
-      UserService.getUser({ email }),
-      UserService.getUser({ username }),
+      UserService.getUserComplete({ email }),
+      UserService.getUserComplete({ username }),
     ]);
 
     if (!userByUsername || !userByEmail) {

--- a/api/modules/auth/controller.ts
+++ b/api/modules/auth/controller.ts
@@ -221,15 +221,9 @@ const AuthController = {
   login: async (req: Request, res: Response, next: NextFunction) => {
     const { username, password } = req.body;
 
-    // Safe compare usernames.
+    // Safe compare usernames. Usernames are case-insensitive.
     const user = await UserService.getUserComplete({ username });
     if (!user) {
-      next(new AppError('Invalid username and/or password!', 401));
-      return;
-    }
-
-    // MySQL is not good at case-sensitive comparisons, so we do this manually.
-    if (!safeCompare(user.username, username)) {
       next(new AppError('Invalid username and/or password!', 401));
       return;
     }

--- a/api/modules/user/service.ts
+++ b/api/modules/user/service.ts
@@ -11,7 +11,6 @@ import { hashPassword } from '../../util/passwords';
  */
 const select = Prisma.validator<Prisma.UserSelect>()({
   userID: true,
-  username: true,
   email: true,
   phoneNumber: true,
   fullName: true,

--- a/web/components/Pages/Register/RegisterForm.tsx
+++ b/web/components/Pages/Register/RegisterForm.tsx
@@ -84,7 +84,7 @@ const RegisterForm = ({ setQRCode, setOpenDialog, setDialogName }: Props) => {
         placeholder="kharansyah"
         value={username}
         setValue={setUsername}
-        helper="Your preferred username to be used to login. Usernames are case-sensitive and trailing whitespaces will be removed automatically."
+        helper="Your preferred username to be used to login. Usernames are not case-sensitive and trailing whitespaces will be removed automatically."
         type="text"
       />
 

--- a/web/utils/types.ts
+++ b/web/utils/types.ts
@@ -74,7 +74,6 @@ export type Session = {
  */
 export type User = {
   userID: string;
-  username: string;
   email: string;
   phoneNumber: string;
   fullName: string;


### PR DESCRIPTION
Implements:

- Do not return `username` in `getUser` service method. That attribute is not used anywhere and is just an unnecessary exposure.
- Allow case-insensitive usernames for increased usability. According to OWASP, it is OK.
- Use `getUserComplete` for password forgots.